### PR TITLE
Fix some Dex crashes

### DIFF
--- a/src/pokedex.c
+++ b/src/pokedex.c
@@ -2652,7 +2652,11 @@ static void UpdateSelectedMonSpriteId(void)
     {
         u16 spriteId = sPokedexView->monSpriteIds[i];
 
+#ifndef UBFIX
         if (gSprites[spriteId].pos2.x == 0 && gSprites[spriteId].pos2.y == 0 && spriteId != 0xFFFF)
+#else
+        if (spriteId != 0xFFFF && gSprites[spriteId].pos2.x == 0 && gSprites[spriteId].pos2.y == 0)
+#endif
             sPokedexView->selectedMonSpriteId = spriteId;
     }
 }


### PR DESCRIPTION
Not sure if the 0th entry of a 256 color palette is considered transparent, but I don't think so?