### PR TITLE
Fix use after free crash in elite four mugshot transition code

### DIFF
--- a/src/battle_transition.c
+++ b/src/battle_transition.c
@@ -951,6 +951,9 @@ bool8 IsBattleTransitionDone(void)
     if (gTasks[taskId].tTransitionDone)
     {
         DestroyTask(taskId);
+        #ifdef PORTABLE
+        SetHBlankCallback(NULL); //prevents use after free crash in HBlankCB_Phase2_Mugshots
+        #endif
         FREE_AND_SET_NULL(sTransitionStructPtr);
         return TRUE;
     }


### PR DESCRIPTION
This is caused by HBlank interrupt calling HBlankCB_Phase2_Mugshots even though sTransitionStructPtr was freed.
I fixed it by disabling HBlank in IsBattleTransitionDone before the sTransitionStructPtr is freed.
This fix should not interfere with any other code that uses HBlank because it will always go into battle system