### PR TITLE
Workaround out of bounds cry decompress during lotad wild battle in route 102

### DIFF
--- a/src/sound_mixer.c
+++ b/src/sound_mixer.c
@@ -465,6 +465,13 @@ static s8 sub_82DF758(struct MixerSource *chan, u32 current) {
     u32 blockOffset = current >> 6; // current / 64
     u8 * blockPtr;
     int i;
+    //In route 102 lotad wild battle when it growls crashes the game because it decompresses out of bounds data
+    //I gave it its own printf error so it wouldn't get forgotten as this needs a more proper fix
+    if (chan->wav->size < blockOffset * 0x21) {
+            printf("Out of bounds decompress in %s wav->size = %u blockPtr = %u\n", __func__, chan->wav->size, blockOffset * 0x21);
+            return gBDPCMBlockBuffer[current & 63];
+    }
+    
     if(chan->blockCount != blockOffset) { // decode block if not decoded
         s32 s;
         chan->blockCount = blockOffset;


### PR DESCRIPTION
This crash happens when lotad in route 102 growls, its related to pokemon cry decompression. This workaround fixes the issue by doing a bounds check.
I have decided to give its own printf error message so it wouldn't be forgotten as this probably needs a proper fix