### PR TITLE
Simplified installation and makefile, added proper INSTALL.md instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ prefabs.json
 *.diff
 *.sym
 *.js
+SDL2-2.30.1
+SDL2.dll

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 # Instructions
 
-These instructions explain how to set up the tools required to build **pokeemerald_pc**, which assembles the source files into a ROM.
+These instructions explain how to set up the tools required to build **pokeemerald_pc**, which assembles the source files into an EXE or ROM.
 
 These instructions come with notes which can be expanded by clicking the "<i>Note...</i>" text.
 In general, you should not need to open these unless if you get an error or if you need additional clarification.
@@ -103,9 +103,7 @@ Some tips before proceeding:
     ```
 
 ### Choosing where to store pokeemerald_pc (WSL2)
-WSL2 has its own file system that's not natively accessible from Windows.
-
-Windows files *are* accessible from WSL, but accessing Windows files using WSL2 is incredibly slow, so you want to store your files in the WSL filesystem.
+WSL has its own file system. Windows files *are* accessible from WSL, but accessing Windows files using WSL2 is incredibly slow, so you want to store your files in the WSL filesystem.
 
 We'll make a `decomps` folder for organisation:
 
@@ -262,22 +260,22 @@ If this works, then proceed to [Installation](#installation).
 
 If pokeemerald_pc is not already downloaded (some users may prefer to download pokeemerald_pc via a git client like GitHub Desktop), run:
 
-    ```bash
-    git clone https://github.com/Kurausukun/pokeemerald -b pc_port pokeemerald_pc
-    ```
+```bash
+git clone https://github.com/Kurausukun/pokeemerald -b pc_port pokeemerald_pc
+```
 
-    <details>
-        <summary><i>Note for WSL2...</i></summary>
+<details>
+    <summary><i>Note for WSL2...</i></summary>
 
-    >   If you get an error stating `fatal: could not set 'core.filemode' to 'false'`, then run the following commands:
-    >   ```bash
-    >   cd
-    >   sudo umount /mnt/c
-    >   sudo mount -t drvfs C: /mnt/c -o metadata,noatime
-    >   cd <folder where pokeemerald_pc is to be stored>
-    >   ```
-    >   Where *\<folder where pokeemerald_pc is to be stored>* is the path of the folder [where you chose to store pokeemerald_pc](#Choosing-where-to-store-pokeemerald_pc-WSL2). Then run the `git clone` command again.
-    </details>
+>   If you get an error stating `fatal: could not set 'core.filemode' to 'false'`, then run the following commands:
+>   ```bash
+>   cd
+>   sudo umount /mnt/c
+>   sudo mount -t drvfs C: /mnt/c -o metadata,noatime
+>   cd <folder where pokeemerald_pc is to be stored>
+>   ```
+>   Where *\<folder where pokeemerald_pc is to be stored>* is the path of the folder [where you chose to store pokeemerald_pc](#Choosing-where-to-store-pokeemerald_pc-WSL2). Then run the `git clone` command again.
+</details>
 
 Now move on to [downloading the SDL Libraries](#sdl_libraries).
 
@@ -285,7 +283,7 @@ Now move on to [downloading the SDL Libraries](#sdl_libraries).
 
 1. Download SDL from: https://github.com/libsdl-org/SDL/releases. You need the Development Libraries for MinGW specifically, and the Runtime Library for 32-bit Windows as well.
     <details>
-        <summary><i>Releases</i></summary>
+        <summary><i>Note for Releases</i></summary>
 
     >   You can download any recent version of SDL2.
     >   The Development Libaries for MinGW will be called SDL2-devel-x.xx.x-mingw.tar.gz
@@ -296,11 +294,10 @@ Now move on to [downloading the SDL Libraries](#sdl_libraries).
 
 3. Uncompress the Runtime libraries, then move the SDL2.dll file into your **pokeemerald_pc** folder.
 
-4. Adjust the path to SDL in **pokeemerald_pc**'s `Makefile_pc` if needed, like so:
+4. Use your preferred text editor to adjust the path to SDL in **pokeemerald_pc**'s `Makefile_pc` if needed, like so:
 
-```make
-SDL_DIR := $(CURDIR)/SDL2-x.xx.x/i686-w64-mingw32
-```
+> SDL_DIR := $(CURDIR)/SDL2-x.xx.x/i686-w64-mingw32
+
 Where SDL2-x.xx.x is your exact version of SDL2.
 
 Finally, you are ready to [build **pokeemerald_pc**](#build-pokeemerald_pc)
@@ -311,31 +308,30 @@ If you aren't in the pokeemerald_pc directory already, then **change directory**
 cd pokeemerald_pc
 ```
 
-To build **pokeemerald_pc.exe** (Note: to speed up builds, see [Parallel builds](#parallel-builds)):
+To build **pokeemerald_pc.exe**:
 ```bash
-make tools
-make -f Makefile_pc
+make pc
 ```
 If it has built successfully you will have the output file **pokeemerald_pc.exe** in your project folder.
 
-To build **pokeemerald_pc.gba** (Note: to speed up builds, see [Parallel builds](#parallel-builds)):
+To build **pokeemerald_pc.gba**:
 ```bash
 make
 ```
 If it has built successfully you will have the output file **pokeemerald_pc.gba** in your project folder.
 
-    <details>
-        <summary><i>Note for -jN...</i></summary>
+<details>
+    <summary><i>Note for -jN...</i></summary>
 
-    >   To speed up the build time add -jN to your command.
-    >   e.g., `make -f Makefile_pc -jN`
-    >   
-    >   "N" stands for the number of CPU Threads you want to assign to the compiler.
-    >   The more threads, the faster it'll go.
-    >
-    >   Use command `nproc` to get the total core count of your system.
-    >   `nproc` is not available on macOS. The alternative is `sysctl -n hw.ncpu`.
-    </details>
+>   To speed up the build time add -jN to your command.
+>   e.g., `make -f Makefile_pc -jN`
+>   
+>   "N" stands for the number of CPU Threads you want to assign to the compiler.
+>   The more threads, the faster it'll go.
+>
+>   Use command `nproc` to get the total core count of your system.
+>   `nproc` is not available on macOS. The alternative is `sysctl -n hw.ncpu`.
+</details>
 
 # Building guidance
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,38 +1,23 @@
 # Instructions
 
-These instructions explain how to set up the tools required to build **pokeemerald**, which assembles the source files into a ROM.
+These instructions explain how to set up the tools required to build **pokeemerald_pc**, which assembles the source files into a ROM.
 
 These instructions come with notes which can be expanded by clicking the "<i>Note...</i>" text.
 In general, you should not need to open these unless if you get an error or if you need additional clarification.
 
 If you run into trouble, ask for help on Discord or IRC (see [README.md](README.md)).
 
-## Windows
-Windows has instructions for building with three possible terminals, providing 3 different options in case the user stumbles upon unexpected errors.
-- [Windows 10/11 (WSL1)](#windows-1011-wsl1) (**Fastest, highly recommended**, Windows 10 and 11 only)
-- [Windows (msys2)](#windows-msys2) (Second fastest)
-- [Windows (Cygwin)](#windows-cygwin) (Slowest)
+- [Windows 10/11](#windows-1011-wsl2)
+- [MacOS](#macos)
+- [Linux](#linux)
 
-Unscientific benchmarks suggest **msys2 is 2x slower** than WSL1, and **Cygwin is 5-6x slower** than WSL1.
-<details>
-    <summary><i>Note for advanced users: <b>WSL2</b>...</i></summary>
+## Windows 10/11 (WSL2)
+WSL2 is the preferred terminal to build **pokeemerald_pc**. The following instructions will explain how to install WSL2 (referred to interchangeably as WSL).
+- If WSL (Debian or Ubuntu) is **not installed**, then go to [Installing WSL2](#Installing-WSL2).
+- Otherwise, if WSL is installed, but it **hasn't previously been set up for another decompilation project**, then go to [Setting up WSL2](#Setting-up-WSL2).
+- Otherwise, **open WSL** and go to [Choosing where to store pokeemerald_pc (WSL2)](#Choosing-where-to-store-pokeemerald_pc-WSL2).
 
->   <b>WSL2</b> is an option and is even faster than <b>WSL1</b> if files are stored on the WSL2 file system, but some tools may have trouble interacting
->   with the WSL2 file system over the network drive. For example, tools which use Qt versions before 5.15.2 such as <a href="https://github.com/huderlem/porymap">porymap</a>
->   may <a href="https://bugreports.qt.io/browse/QTBUG-86277">have problems with parsing the <code>\\wsl$</code> network drive path</a>.
-</details>
-
-All of the Windows instructions assume that the default drive is C:\\. If this differs to your actual drive letter, then replace C with the correct drive letter when reading the instructions.
-
-**A note of caution**: As Windows 7 is officially unsupported by Microsoft and Windows 8 has very little usage, some maintainers are unwilling to maintain the Windows 7/8 instructions. Thus, these instructions may break in the future with fixes taking longer than fixes to the Windows 10 instructions.
-
-## Windows 10/11 (WSL1)
-WSL1 is the preferred terminal to build **pokeemerald**. The following instructions will explain how to install WSL1 (referred to interchangeably as WSL).
-- If WSL (Debian or Ubuntu) is **not installed**, then go to [Installing WSL1](#Installing-WSL1).
-- Otherwise, if WSL is installed, but it **hasn't previously been set up for another decompilation project**, then go to [Setting up WSL1](#Setting-up-WSL1).
-- Otherwise, **open WSL** and go to [Choosing where to store pokeemerald (WSL1)](#Choosing-where-to-store-pokeemerald-WSL1).
-
-### Installing WSL1
+### Installing WSL2
 1. Open [Windows Powershell **as Administrator**](https://i.imgur.com/QKmVbP9.png), and run the following command (Right Click or Shift+Insert is paste in the Powershell).
 
     ```powershell
@@ -56,7 +41,7 @@ WSL1 is the preferred terminal to build **pokeemerald**. The following instructi
     >   Note 2: If the link does not work, then open the Microsoft Store manually, and search for the Ubuntu app (choose the one with no version number).
     </details>
 
-### Setting up WSL1
+### Setting up WSL2
 Some tips before proceeding:
 - In WSL, Copy and Paste is either done via
     - **right-click** (selection + right click to Copy, right click with no selection to Paste)
@@ -77,12 +62,10 @@ Some tips before proceeding:
     sudo apt update && sudo apt upgrade
     ```
 
-> Note: If the repository you plan to build has an **[older revision of the INSTALL.md](https://github.com/pret/pokeemerald/blob/571c598/INSTALL.md)**, then follow the [legacy WSL1 instructions](docs/legacy_WSL1_INSTALL.md) from here.
-
-4. Certain packages are required to build pokeemerald. Install these packages by running the following command:
+4. Certain packages are required to build pokeemerald_pc. Install these packages by running the following command:
 
     ```bash
-    sudo apt install build-essential binutils-arm-none-eabi git libpng-dev
+    sudo apt install build-essential binutils-arm-none-eabi git libpng-dev gdebi-core make g++-mingw-w64-i686
     ```
     <details>
         <summary><i>Note...</i></summary>
@@ -90,168 +73,54 @@ Some tips before proceeding:
     >   If the above command does not work, try the above command but replacing `apt` with `apt-get`.
     </details>
 
-### Choosing where to store pokeemerald (WSL1)
-WSL has its own file system that's not natively accessible from Windows, but Windows files *are* accessible from WSL. So you're going to want to store pokeemerald within Windows.
+5. Once `gdebi-core` is done installing, download the devkitPro pacman package [here](https://github.com/devkitPro/pacman/releases). The file to download is `devkitpro-pacman.amd64.deb`.
 
-For example, say you want to store pokeemerald (and agbcc) in **C:\Users\\_\<user>_\Desktop\decomps**. First, ensure that the folder already exists. Then, enter this command to **change directory** to said folder, where *\<user>* is your **Windows** username:
+6. Change directory to where the package was downloaded. For example, if the package file was saved to **C:\Users\\_\<user>_\Downloads** (the Downloads location for most users), enter this command, where *\<user> is your **Windows** username:
+
+    ```bash
+    cd /mnt/c/Users/<user>/Downloads
+    ```
+
+7. Once the directory has been changed to the folder containing the devkitPro pacman package, run the following commands to install devkitARM.
+
+    ```bash
+    sudo gdebi devkitpro-pacman.amd64.deb
+    sudo dkp-pacman -Sy
+    sudo dkp-pacman -S gba-dev
+    ```
+    The last command will ask for the selection of packages to install. Just press Enter to install all of them, followed by entering Y to proceed with the installation.
+
+    <details>
+        <summary><i>Note...</i></summary>
+
+    > Note: `devkitpro-pacman.amd64.deb` is the expected filename of the devkitPro package downloaded (for the first command). If the downloaded package filename differs, then use that filename instead.
+    </details>
+
+8. Run the following command to set devkitPro related environment variables (alternatively, close and re-open WSL):
+
+    ```bash
+    source /etc/profile.d/devkit-env.sh
+    ```
+
+### Choosing where to store pokeemerald_pc (WSL2)
+WSL2 has its own file system that's not natively accessible from Windows.
+
+Windows files *are* accessible from WSL, but accessing Windows files using WSL2 is incredibly slow, so you want to store your files in the WSL filesystem.
+
+We'll make a `decomps` folder for organisation:
 
 ```bash
-cd /mnt/c/Users/<user>/Desktop/decomps
+mkdir decomps && cd decomps
 ```
 
 <details>
     <summary><i>Notes...</i></summary>
 
->   Note 1: The Windows C:\ drive is called /mnt/c/ in WSL.
->   Note 2: If the path has spaces, then the path must be wrapped with quotations, e.g. `cd "/mnt/c/users/<user>/Desktop/decomp folder"`.
->   Note 3: Windows path names are case-insensitive so adhering to capitalization isn't needed
+>   Note 1: The WSL file system appears in Windows similar to network folders. You can find 'Linux' at the bottom of your Quick Access menu.
+>   Note 2: It is suggested that you go into your file explorer in Windows, find the WSL file system and pin your decomps folder for easier access.
 </details>
 
 If this works, then proceed to [Installation](#installation).
-
-Otherwise, ask for help on Discord or IRC (see [README.md](README.md)), or continue reading below for [Windows instructions using msys2](#windows-msys2).
-
-## Windows (msys2)
-
-- If devkitARM is **not installed**, then go to [Installing devkitARM](#installing-devkitarm).
-- If devkitARM is installed, but msys2 **hasn't previously been set up for another decompilation project**, then go to [Setting up msys2](#setting-up-msys2).
-- Otherwise, **open msys2** and go to [Choosing where to store pokeemerald (msys2)](#choosing-where-to-store-pokeemerald-msys2).
-
-### Installing devkitARM
-1. Download the devkitPro installer [here](https://github.com/devkitPro/installer/releases).
-2. Run the devkitPro installer. In the "Choose Components" screen, uncheck everything except GBA Development unless if you plan to install other devkitPro components for other purposes. Keep the install location as C:\devkitPro and leave the Start Menu option unchanged.
-
-### Setting up msys2
-
-Note that in msys2, Copy is Ctrl+Insert and Paste is Shift+Insert.
-
-1. Open msys2 at C:\devkitPro\msys2\msys2_shell.bat.
-
-2. Certain packages are required to build pokeemerald. Install these by running the following two commands:
-
-    ```bash
-    pacman -Sy msys2-keyring
-    pacman -S make gcc zlib-devel git
-    ```
-    <details>
-        <summary><i>Note...</i></summary>
-
-    >   The commands will ask for confirmation, just enter the yes action when prompted.
-    </details>
-
-3. Download [libpng](https://sourceforge.net/projects/libpng/files/libpng16/1.6.37/libpng-1.6.37.tar.xz/download).
-
-4. Change directory to where libpng was downloaded. By default, msys2 will start in the current user's profile folder, located at **C:\Users\\&#8288;_\<user>_**, where *\<user>* is your Windows username. In most cases, libpng should be saved within a subfolder of the profile folder. For example, if libpng was saved to **C:\Users\\_\<user>_\Downloads** (the Downloads location for most users), enter this command:
-
-    ```bash
-    cd Downloads
-    ```
-
-    <details>
-        <summary><i>Notes...</i></summary>
-
-    >   Note 1: While not shown, msys uses forward slashes `/` instead of backwards slashes `\` as the directory separator.
-    >   Note 2: If the path has spaces, then the path must be wrapped with quotations, e.g. `cd "Downloads/My Downloads"`.
-    >   Note 3: Windows path names are case-insensitive so adhering to capitalization isn’t needed.
-    >   Note 4: If libpng was saved elsewhere, you will need to specify the full path to where libpng was downloaded, e.g. `cd c:/devkitpro/msys2` if it was saved there.
-    </details>
-
-5. Run the following commands to uncompress and install libpng.
-
-    ```bash
-    tar xf libpng-1.6.37.tar.xz
-    cd libpng-1.6.37
-    ./configure --prefix=/usr
-    make check
-    make install
-    ```
-
-6. Then finally, run the following command to change back to the user profile folder.
-
-    ```bash
-    cd
-    ```
-
-### Choosing where to store pokeemerald (msys2)
-At this point, you can choose a folder to store pokeemerald into. If you're okay with storing pokeemerald in the user profile folder, then proceed to [Installation](#installation). Otherwise, you'll need to account for where pokeemerald is stored when changing directory to the pokeemerald folder.
-
-For example, if you want to store pokeemerald (and agbcc) in **C:\Users\\_\<user>_\Desktop\decomps** (where *\<user>* is your **Windows** username), enter this command:
-
-```bash
-cd Desktop/decomps
-```
-
-If this works, then proceed to [Installation](#installation).
-
-Otherwise, ask for help on Discord or IRC (see [README.md](README.md)), or continue reading below for [Windows instructions using Cygwin](#windows-cygwin).
-
-## Windows (Cygwin)
-1. If devkitARM is **not installed**, then follow the instructions used to [install devkitARM](#installing-devkitarm) for the msys2 setup before continuing. *Remember to not continue following the msys2 instructions by mistake!*
-
-2.
-    - If Cygwin is **not installed**, or does not have all of the required packages installed, then go to [Installing Cygwin](#installing-cygwin).
-    - If Cygwin is installed, but **is not configured to work with devkitARM**, then go to [Configuring devkitARM for Cygwin](#configuring-devkitarm-for-cygwin).
-    - Otherwise, **open Cygwin** and go to [Choosing where to store pokeemerald (Cygwin)](#choosing-where-to-store-pokeemerald-cygwin)
-
-### Installing Cygwin
-1. Download [Cygwin](https://cygwin.com/install.html): setup-x86_64.exe for 64-bit Windows, setup-x86.exe for 32-bit.
-
-2. Run the Cygwin setup. Within the Cygwin setup, leave the default settings until the "Choose A Download Site" screen.
-
-3. At "Choose a Download Site", select any mirror within the Available Download Sites.
-
-4. At "Select Packages", set the view to "Full" (top left) and search for the following packages:
-    - `make`
-    - `git`
-    - `gcc-core`
-    - `gcc-g++`
-    - `libpng-devel`
-
-    To quickly find these, use the search bar and type the name of each package. Ensure that the selected package name is the **exact** same as the one you're trying to download, e.g. `cmake` is **NOT** the same as `make`.
-
-5. For each package, double click on the text that says "**Skip**" next to each package to select the most recent version to install. If the text says anything other than "**Skip**", (e.g. Keep or a version number), then the package is or will be installed and you don't need to do anything.
-
-6. Once all required packages have been selected, finish the installation.
-
-### Configuring devkitARM for Cygwin
-
-Note that in Cygwin, Copy is Ctrl+Insert and Paste is Shift+Insert.
-
-1. Open **Cygwin**.
-
-2. Run the following commands to configure devkitPro to work with Cygwin.
-
-    ```bash
-    export DEVKITPRO=/cygdrive/c/devkitpro
-    echo export DEVKITPRO=$DEVKITPRO >> ~/.bashrc
-    export DEVKITARM=$DEVKITPRO/devkitARM
-    echo export DEVKITARM=$DEVKITARM >> ~/.bashrc
-    ```
-
-    <details>
-        <summary><i>Note...</i></summary>
-
-    >   Replace the drive letter c with the actual drive letter if it is not c.
-    </details>
-
-### Choosing where to store pokeemerald (Cygwin)
-
-Cygwin has its own file system that's within Windows, at **C:\cygwin64\home\\_\<user>_**. If you don't want to store pokeemerald there, you'll need to account for where pokeemerald is stored when **changing directory** to the pokeemerald folder.
-
-For example, if you want to store pokeemerald (and agbcc) in **C:\Users\\_\<user>_\Desktop\decomps**, enter this command, where *\<user>* is your **Windows** username:
-```bash
-cd c:/Users/<user>/Desktop/decomps
-```
-Note that the directory **must exist** in Windows. If you want to store pokeemerald in a dedicated folder that doesn't exist (e.g. the example provided above), then create the folder (e.g. using Windows Explorer) before executing the `cd` command.
-
-<details>
-    <summary><i>Notes...</i></summary>
-
->   Note 1: If the path has spaces, then the path must be wrapped with quotations, e.g. `cd "c:/users/<user>/Desktop/decomp folder"`.
->   Note 2: Windows path names are case-insensitive so adhering to capitalization isn't needed
-</details>
-
-If this works, then proceed to [Installation](#installation). Otherwise, ask for help on Discord or IRC (see [README.md](README.md)).
 
 ## macOS
 1. If the Xcode Command Line Tools are not installed, download the tools [here](https://developer.apple.com/xcode/resources/), open your Terminal, and run the following command:
@@ -262,7 +131,7 @@ If this works, then proceed to [Installation](#installation). Otherwise, ask for
 
 2.  - If libpng is **not installed**, then go to [Installing libpng (macOS)](#installing-libpng-macos).
     - If devkitARM is **not installed**, then go to [Installing devkitARM (macOS)](#installing-devkitarm-macos).
-    - Otherwise, **open the Terminal** and go to [Choosing where to store pokeemerald (macOS)](#choosing-where-to-store-pokeemerald-macos)
+    - Otherwise, **open the Terminal** and go to [Choosing where to store pokeemerald_pc (macOS)](#choosing-where-to-store-pokeemerald_pc-macos)
 
 ### Installing libpng (macOS)
 <details>
@@ -280,7 +149,7 @@ If this works, then proceed to [Installation](#installation). Otherwise, ask for
     ```
     libpng is now installed.
 
-    Continue to [Installing devkitARM (macOS)](#installing-devkitarm-macos) if **devkitARM is not installed**, otherwise, go to [Choosing where to store pokeemerald (macOS)](#choosing-where-to-store-pokeemerald-macos).
+    Continue to [Installing devkitARM (macOS)](#installing-devkitarm-macos) if **devkitARM is not installed**, otherwise, go to [Choosing where to store pokeemerald_pc (macOS)](#choosing-where-to-store-pokeemerald_pc-macos).
 
 ### Installing devkitARM (macOS)
 1. Download the `devkitpro-pacman-installer.pkg` package from [here](https://github.com/devkitPro/pacman/releases).
@@ -306,14 +175,22 @@ If this works, then proceed to [Installation](#installation). Otherwise, ask for
     echo "if [ -f ~/.bashrc ]; then . ~/.bashrc; fi" >> ~/.bash_profile
     ```
 
-### Choosing where to store pokeemerald (macOS)
-At this point, you can choose a folder to store pokeemerald into. If you're okay with storing pokeemerald in the user folder, then proceed to [Installation](#installation). Otherwise, you'll need to account for where pokeemerald is stored when changing directory to the pokeemerald folder.
+### Installing pkg-config (macOS)
+1. Open the terminal.
+2. Run the following command to install pkg-config:
 
-For example, if you want to store pokeemerald (and agbcc) in **~/Desktop/decomps**, enter this command to **change directory** to the desired folder:
+    ```bash
+    brew install pkg-config
+    ```
+
+### Choosing where to store pokeemerald_pc (macOS)
+At this point, you can choose a folder to store pokeemerald_pc into. If you're okay with storing pokeemerald_pc in the user folder, then proceed to [Installation](#installation). Otherwise, you'll need to account for where pokeemerald_pc is stored when changing directory to the pokeemerald_pc folder.
+
+For example, if you want to store pokeemerald_pc (and agbcc) in **~/Desktop/decomps**, enter this command to **change directory** to the desired folder:
 ```bash
 cd Desktop/decomps
 ```
-Note that the directory **must exist** in the folder system. If you want to store pokeemerald in a dedicated folder that doesn't exist (e.g. the example provided above), then create the folder (e.g. using Finder) before executing the `cd` command.
+Note that the directory **must exist** in the folder system. If you want to store pokeemerald_pc in a dedicated folder that doesn't exist (e.g. the example provided above), then create the folder (e.g. using Finder) before executing the `cd` command.
 
 <details>
     <summary><i>Note..</i>.</summary>
@@ -321,238 +198,19 @@ Note that the directory **must exist** in the folder system. If you want to stor
 >   Note: If the path has spaces, then the path must be wrapped with quotations, e.g. `cd "Desktop/decomp folder"`
 </details>
 
-If this works, then proceed to [Installation](#installation). Otherwise, ask for help on Discord or IRC (see [README.md](README.md)).
+If this works, then proceed to [Installation](#installation).
 
 ## Linux
 Open Terminal and enter the following commands, depending on which distro you're using.
 
 ### Debian/Ubuntu-based distributions
-Run the following command to install the necessary packages:
-```bash
-sudo apt install build-essential binutils-arm-none-eabi git libpng-dev
-```
-Then proceed to [Choosing where to store pokeemerald (Linux)](#choosing-where-to-store-pokeemerald-linux).
-<details>
-    <summary><i>Note for legacy repos...</i></summary>
-
->   If the repository you plan to build has an **[older revision of the INSTALL.md](https://github.com/pret/pokeemerald/blob/571c598/INSTALL.md)**,
->   then you will have to install devkitARM. Install all the above packages except binutils-arm-none-eabi, and follow the instructions to
->   [install devkitARM on Debian/Ubuntu-based distributions](#installing-devkitarm-on-debianubuntu-based-distributions).
-</details>
-
-### Arch Linux
-Run this command as root to install the necessary packages:
-```bash
-pacman -S base-devel arm-none-eabi-binutils git libpng
-```
-Then proceed to [Choosing where to store pokeemerald (Linux)](#choosing-where-to-store-pokeemerald-linux).
-<details>
-    <summary><i>Note for legacy repos...</i></summary>
-
->   If the repository you plan to build has an **[older revision of the INSTALL.md](https://github.com/pret/pokeemerald/blob/571c598/INSTALL.md)**,
->   then you will have to install devkitARM. Install all the above packages except binutils-arm-none-eabi, and follow the instructions to
->   [install devkitARM on Arch Linux](#installing-devkitarm-on-arch-linux).
-</details>
-
-### Other distributions
-_(Specific instructions for other distributions would be greatly appreciated!)_
-
-1. Try to find the required software in its repositories:
-    - `gcc`
-    - `g++`
-    - `make`
-    - `git`
-    - `libpng-dev`
-
-2. Follow the instructions [here](https://devkitpro.org/wiki/devkitPro_pacman) to install devkitPro pacman. As a reminder, the goal is to configure an existing pacman installation to recognize devkitPro's repositories.
-3. Once devkitPro pacman is configured, run the following commands:
-
+1. Run the following command to install the necessary packages:
     ```bash
-    sudo pacman -Sy
-    sudo pacman -S gba-dev
+    sudo apt install build-essential binutils-arm-none-eabi git libpng-dev gdebi-core make g++-mingw-w64-i686
     ```
 
-    The last command will ask for the selection of packages to install. Just press Enter to install all of them, followed by entering Y to proceed with the installation.
-
-### Choosing where to store pokeemerald (Linux)
-At this point, you can choose a folder to store pokeemerald (and agbcc) into. If so, you'll have to account for the modified folder path when changing directory to the pokeemerald folder.
-
-If this works, then proceed to [Installation](#installation). Otherwise, ask for help on Discord or IRC (see [README.md](README.md)).
-
-## Installation
-
-<details>
-    <summary><i>Note for Windows users...</i></summary>
-
->   Consider adding an exception for the `pokeemerald` and/or `decomps` folder in Windows Security using
->   [these instructions](https://support.microsoft.com/help/4028485). This prevents Microsoft Defender from
->   scanning them which might improve performance while building.
-</details>
-
-1. If pokeemerald is not already downloaded (some users may prefer to download pokeemerald via a git client like GitHub Desktop), run:
-
-    ```bash
-    git clone https://github.com/pret/pokeemerald
-    ```
-
-    <details>
-        <summary><i>Note for WSL1...</i></summary>
-
-    >   If you get an error stating `fatal: could not set 'core.filemode' to 'false'`, then run the following commands:
-    >   ```bash
-    >   cd
-    >   sudo umount /mnt/c
-    >   sudo mount -t drvfs C: /mnt/c -o metadata,noatime
-    >   cd <folder where pokeemerald is to be stored>
-    >   ```
-    >   Where *\<folder where pokeemerald is to be stored>* is the path of the folder [where you chose to store pokeemerald](#Choosing-where-to-store-pokeemerald-WSL1). Then run the `git clone` command again.
-    </details>
-
-2. Install agbcc into pokeemerald. The commands to run depend on certain conditions. **You should only follow one of the listed instructions**:
-- If agbcc has **not been built before** in the folder where you chose to store pokeemerald, run the following commands to build and install it into pokeemerald:
-
-    ```bash
-    git clone https://github.com/pret/agbcc
-    cd agbcc
-    ./build.sh
-    ./install.sh ../pokeemerald
-    ```
-
-- **Otherwise**, if agbcc has been built before (e.g. if the git clone above fails), but was **last built on a different terminal** than the one currently used (only relevant to Windows, e.g. switching from msys2 to WSL1), then run the following commands to build and install it into pokeemerald:
-
-    ```bash
-    cd agbcc
-    git clean -fX
-    ./build.sh
-    ./install.sh ../pokeemerald
-    ```
-
-- **Otherwise**, if agbcc has been built before on the same terminal, run the following commands to install agbcc into pokeemerald:
-
-    ```bash
-    cd agbcc
-    ./install.sh ../pokeemerald
-    ```
-
-    <details>
-        <summary><i>Note...</i></summary>
-
-        > If building agbcc or pokeemerald results in an error, try deleting the agbcc folder and re-installing agbcc as if it has not been built before.
-    </details>
-
-3. Once agbcc is installed, change directory back to the base directory where pokeemerald and agbcc are stored:
-
-    ```bash
-    cd ..
-    ```
-
-Now you're ready to [build **pokeemerald**](#build-pokeemerald)
-## Build pokeemerald
-If you aren't in the pokeemerald directory already, then **change directory** to the pokeemerald folder:
-```bash
-cd pokeemerald
-```
-To build **pokeemerald.gba** (Note: to speed up builds, see [Parallel builds](#parallel-builds)):
-```bash
-make
-```
-If it has built successfully you will have the output file **pokeemerald.gba** in your project folder.
-<details>
-<summary>Note for Windows...</summary>
-> If you switched terminals since the last build (e.g. from msys2 to WSL1), you must run `make clean-tools` once before any subsequent `make` commands.
-</details>
-
-# Building guidance
-
-## Parallel builds
-
-See [the GNU docs](https://www.gnu.org/software/make/manual/html_node/Parallel.html) and [this Stack Exchange thread](https://unix.stackexchange.com/questions/208568) for more information.
-
-To speed up building, first get the value of `nproc` by running the following command:
-```bash
-nproc
-```
-Builds can then be sped up by running the following command:
-```bash
-make -j<output of nproc>
-```
-Replace `<output of nproc>` with the number that the `nproc` command returned.
-
-`nproc` is not available on macOS. The alternative is `sysctl -n hw.ncpu` ([relevant Stack Overflow thread](https://stackoverflow.com/questions/1715580)).
-
-## Compare ROM to the original
-
-For contributing, or if you'd simply like to verify that your ROM is identical to the original game, run:
-```bash
-make compare
-```
-If it matches, you will see the following at the end of the output:
-```bash
-pokeemerald.gba: OK
-```
-If there are any changes from the original game, you will instead see:
-```bash
-pokeemerald.gba: FAILED
-shasum: WARNING: 1 computed checksum did NOT match
-```
-
-## devkitARM's C compiler
-
-This project supports the `arm-none-eabi-gcc` compiler included with devkitARM. If devkitARM (a.k.a. gba-dev) has already been installed as part of the platform-specific instructions, simply run:
-```bash
-make modern
-```
-Otherwise, follow the instructions below to install devkitARM.
-### Installing devkitARM on WSL1
-
-1. `gdebi-core` must be installed beforehand in order to install devkitPro pacman (which facilitates the installation of devkitARM). Install this with the following command:
-
-    ```bash
-    sudo apt install gdebi-core
-    ```
-    <details>
-        <summary><i>Note...</i></summary>
-
-    >   If the above command does not work, try the above command but replacing `apt` with `apt-get`.
-    </details>
-
-2. Once `gdebi-core` is done installing, download the devkitPro pacman package [here](https://github.com/devkitPro/pacman/releases). The file to download is `devkitpro-pacman.amd64.deb`.
-3. Change directory to where the package was downloaded. For example, if the package file was saved to **C:\Users\\_\<user>_\Downloads** (the Downloads location for most users), enter this command, where *\<user> is your **Windows** username:
-
-    ```bash
-    cd /mnt/c/Users/<user>/Downloads
-    ```
-
-4. Once the directory has been changed to the folder containing the devkitPro pacman package, run the following commands to install devkitARM.
-
-    ```bash
-    sudo gdebi devkitpro-pacman.amd64.deb
-    sudo dkp-pacman -Sy
-    sudo dkp-pacman -S gba-dev
-    ```
-    The last command will ask for the selection of packages to install. Just press Enter to install all of them, followed by entering Y to proceed with the installation.
-
-    <details>
-        <summary><i>Note...</i></summary>
-
-    > Note: `devkitpro-pacman.amd64.deb` is the expected filename of the devkitPro package downloaded (for the first command). If the downloaded package filename differs, then use that filename instead.
-    </details>
-
-5. Run the following command to set devkitPro related environment variables (alternatively, close and re-open WSL):
-
-    ```bash
-    source /etc/profile.d/devkit-env.sh
-    ```
-
-devkitARM is now installed.
-
-### Installing devkitARM on Debian/Ubuntu-based distributions
-1. If `gdebi-core` is not installed, run the following command:
-
-    ```bash
-    sudo apt install gdebi-core
-    ```
 2. Download the devkitPro pacman package [here](https://github.com/devkitPro/pacman/releases). The file to download is `devkitpro-pacman.amd64.deb`.
+
 3. Change directory to where the package was downloaded. Then, run the following commands to install devkitARM:
 
     ```bash
@@ -570,25 +228,132 @@ devkitARM is now installed.
     source /etc/profile.d/devkit-env.sh
     ```
 
-devkitARM is now installed.
+Then proceed to [Choosing where to store pokeemerald_pc (Linux)](#choosing-where-to-store-pokeemerald_pc-linux).
 
-### Installing devkitARM on Arch Linux
+### Other distributions
+_(Specific instructions for other distributions would be greatly appreciated!)_
 
-1. Follow [devkitPro's instructions](https://devkitpro.org/wiki/devkitPro_pacman#Customising_Existing_Pacman_Install) to configure `pacman` to download devkitPro packages.
-2. Install `gba-dev`: run the following command as root.
+1. Try to find the required software in its repositories:
+    - `gcc`
+    - `g++`
+    - `make`
+    - `git`
+    - `libpng-dev`
+    - `gdebi-core`
+    - `make` 
+    - `g++-mingw-w64-i686`
 
-    ```console
-    pacman -S gba-dev
-    ```
-    This will ask for the selection of packages to install. Just press Enter to install all of them, followed by entering Y to proceed with the installation.
-
-3. Run the following command to set devkitPro related environment variables (alternatively, close and re-open the Terminal):
+2. Follow the instructions [here](https://devkitpro.org/wiki/devkitPro_pacman) to install devkitPro pacman. As a reminder, the goal is to configure an existing pacman installation to recognize devkitPro's repositories.
+3. Once devkitPro pacman is configured, run the following commands:
 
     ```bash
-    source /etc/profile.d/devkit-env.sh
+    sudo pacman -Sy
+    sudo pacman -S gba-dev
     ```
 
-devkitARM is now installed.
+    The last command will ask for the selection of packages to install. Just press Enter to install all of them, followed by entering Y to proceed with the installation.
+
+### Choosing where to store pokeemerald_pc (Linux)
+At this point, you can choose a folder to store pokeemerald_pc into. If so, you'll have to account for the modified folder path when changing directory to the pokeemerald_pc folder.
+
+If this works, then proceed to [Installation](#installation).
+
+## Installation
+
+If pokeemerald_pc is not already downloaded (some users may prefer to download pokeemerald_pc via a git client like GitHub Desktop), run:
+
+    ```bash
+    git clone https://github.com/Kurausukun/pokeemerald -b pc_port pokeemerald_pc
+    ```
+
+    <details>
+        <summary><i>Note for WSL2...</i></summary>
+
+    >   If you get an error stating `fatal: could not set 'core.filemode' to 'false'`, then run the following commands:
+    >   ```bash
+    >   cd
+    >   sudo umount /mnt/c
+    >   sudo mount -t drvfs C: /mnt/c -o metadata,noatime
+    >   cd <folder where pokeemerald_pc is to be stored>
+    >   ```
+    >   Where *\<folder where pokeemerald_pc is to be stored>* is the path of the folder [where you chose to store pokeemerald_pc](#Choosing-where-to-store-pokeemerald_pc-WSL2). Then run the `git clone` command again.
+    </details>
+
+Now move on to [downloading the SDL Libraries](#sdl_libraries).
+
+## SDL Libraries
+
+1. Download SDL from: https://github.com/libsdl-org/SDL/releases. You need the Development Libraries for MinGW specifically, and the Runtime Library for 32-bit Windows as well.
+    <details>
+        <summary><i>Releases</i></summary>
+
+    >   You can download any recent version of SDL2.
+    >   The Development Libaries for MinGW will be called SDL2-devel-x.xx.x-mingw.tar.gz
+    >   The Runtime Libary will be called SDL2-x.xx.x-win32-x86.zip
+    </details>
+
+2. Uncompress the Development libraries, then move the SDL2-x.xx.x folder into your **pokeemerald_pc** folder.
+
+3. Uncompress the Runtime libraries, then move the SDL2.dll file into your **pokeemerald_pc** folder.
+
+4. Adjust the path to SDL in **pokeemerald_pc**'s `Makefile_pc` if needed, like so:
+
+```make
+SDL_DIR := $(CURDIR)/SDL2-x.xx.x/i686-w64-mingw32
+```
+Where SDL2-x.xx.x is your exact version of SDL2.
+
+Finally, you are ready to [build **pokeemerald_pc**](#build-pokeemerald_pc)
+
+## Build pokeemerald_pc
+If you aren't in the pokeemerald_pc directory already, then **change directory** to the pokeemerald_pc folder:
+```bash
+cd pokeemerald_pc
+```
+
+To build **pokeemerald_pc.exe** (Note: to speed up builds, see [Parallel builds](#parallel-builds)):
+```bash
+make tools
+make -f Makefile_pc
+```
+If it has built successfully you will have the output file **pokeemerald_pc.exe** in your project folder.
+
+To build **pokeemerald_pc.gba** (Note: to speed up builds, see [Parallel builds](#parallel-builds)):
+```bash
+make
+```
+If it has built successfully you will have the output file **pokeemerald_pc.gba** in your project folder.
+
+    <details>
+        <summary><i>Note for -jN...</i></summary>
+
+    >   To speed up the build time add -jN to your command.
+    >   e.g., `make -f Makefile_pc -jN`
+    >   
+    >   "N" stands for the number of CPU Threads you want to assign to the compiler.
+    >   The more threads, the faster it'll go.
+    >
+    >   Use command `nproc` to get the total core count of your system.
+    >   `nproc` is not available on macOS. The alternative is `sysctl -n hw.ncpu`.
+    </details>
+
+# Building guidance
+
+## Compare ROM to the original
+
+For contributing, or if you'd simply like to verify that your ROM is identical to the original game, run:
+```bash
+make compare
+```
+If it matches, you will see the following at the end of the output:
+```bash
+pokeemerald_pc.gba: OK
+```
+If there are any changes from the original game, you will instead see:
+```bash
+pokeemerald_pc.gba: FAILED
+shasum: WARNING: 1 computed checksum did NOT match
+```
 
 ### Other toolchains
 
@@ -601,14 +366,6 @@ The following is an example:
 make TOOLCHAIN="/usr/local/arm-none-eabi"
 ```
 To compile the `modern` target with this toolchain, the subdirectories `lib`, `include`, and `arm-none-eabi` must also be present.
-
-### Building with debug info under a modern toolchain
-
-To build **pokeemerald.elf** with debug symbols under a modern toolchain:
-```bash
-make modern DINFO=1
-```
-Note that this is not necessary for a non-modern build since those are built with debug symbols by default.
 
 # Useful additional tools
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+ifeq (pc,$(MAKECMDGOALS))
+  include Makefile_pc
+else
+
 TOOLCHAIN := $(DEVKITARM)
 COMPARE ?= 0
 
@@ -435,3 +439,5 @@ libagbsyscall:
 
 $(SYM): $(ELF)
 	$(OBJDUMP) -t $< | sort -u | grep -E "^0[2389]" | $(PERL) -p -e 's/^(\w{8}) (\w).{6} \S+\t(\w{8}) (\S+)$$/\1 \2 \3 \4/g' > $@
+
+endif

--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,10 @@ TITLE       := POKEMON EMER
 GAME_CODE   := BPEE
 MAKER_CODE  := 01
 REVISION    := 0
-MODERN      ?= 0
+MODERN      ?= 1
 
-ifeq (modern,$(MAKECMDGOALS))
-  MODERN := 1
+ifeq (agbcc,$(MAKECMDGOALS))
+  MODERN := 0
 endif
 
 # use arm-none-eabi-cpp for macOS
@@ -63,12 +63,12 @@ else
   CPP := $(PREFIX)cpp
 endif
 
-ROM_NAME := pokeemerald.gba
+ROM_NAME := pokeemerald_pc_agbcc.gba
 ELF_NAME := $(ROM_NAME:.gba=.elf)
 MAP_NAME := $(ROM_NAME:.gba=.map)
 OBJ_DIR_NAME := build/emerald
 
-MODERN_ROM_NAME := pokeemerald_modern.gba
+MODERN_ROM_NAME := pokeemerald_pc.gba
 MODERN_ELF_NAME := $(MODERN_ROM_NAME:.gba=.elf)
 MODERN_MAP_NAME := $(MODERN_ROM_NAME:.gba=.map)
 MODERN_OBJ_DIR_NAME := build/modern

--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,10 @@ TITLE       := POKEMON EMER
 GAME_CODE   := BPEE
 MAKER_CODE  := 01
 REVISION    := 0
-MODERN      ?= 1
+MODERN      ?= 0
 
-ifeq (agbcc,$(MAKECMDGOALS))
-  MODERN := 0
+ifeq (modern,$(MAKECMDGOALS))
+  MODERN := 1
 endif
 
 # use arm-none-eabi-cpp for macOS
@@ -67,12 +67,12 @@ else
   CPP := $(PREFIX)cpp
 endif
 
-ROM_NAME := pokeemerald_pc_agbcc.gba
+ROM_NAME := pokeemerald.gba
 ELF_NAME := $(ROM_NAME:.gba=.elf)
 MAP_NAME := $(ROM_NAME:.gba=.map)
 OBJ_DIR_NAME := build/emerald
 
-MODERN_ROM_NAME := pokeemerald_pc.gba
+MODERN_ROM_NAME := pokeemerald_modern.gba
 MODERN_ELF_NAME := $(MODERN_ROM_NAME:.gba=.elf)
 MODERN_MAP_NAME := $(MODERN_ROM_NAME:.gba=.map)
 MODERN_OBJ_DIR_NAME := build/modern

--- a/Makefile_pc
+++ b/Makefile_pc
@@ -86,13 +86,13 @@ MAKEFLAGS += --no-print-directory
 # Secondary expansion is required for dependency variables in object rules.
 .SECONDEXPANSION:
 
-.PHONY: all rom clean compare tidy tools mostlyclean clean-tools $(TOOLDIRS) libagbsyscall modern tidymodern tidynonmodern
+.PHONY: all rom clean compare tidy tools mostlyclean clean-tools pc $(TOOLDIRS) libagbsyscall modern tidymodern tidynonmodern
 
 infoshell = $(foreach line, $(shell $1 | sed "s/ /__SPACE__/g"), $(info $(subst __SPACE__, ,$(line))))
 
 # Build tools when building the rom
 # Disable dependency scanning for clean/tidy/tools
-ifeq (,$(filter-out all rom compare modern,$(MAKECMDGOALS)))
+ifeq (,$(filter-out all rom compare modern pc,$(MAKECMDGOALS)))
 $(call infoshell, $(MAKE) tools)
 else
 NODEP := 1
@@ -133,6 +133,8 @@ AUTO_GEN_TARGETS :=
 $(shell mkdir -p $(SUBDIRS))
 
 all: rom
+
+pc: rom
 
 tools: $(TOOLDIRS)
 

--- a/Makefile_pc
+++ b/Makefile_pc
@@ -3,7 +3,7 @@ OBJCOPY := $(PREFIX)objcopy
 CC := $(PREFIX)gcc
 AS := $(PREFIX)as
 
-SDL_DIR := /home/pokeemerald/SDL2-2.0.14/i686-w64-mingw32
+SDL_DIR := $(CURDIR)/SDL2-2.30.1/i686-w64-mingw32
 ASM_PSEUDO_OP_CONV := sed -e 's/\.4byte/\.int/g;s/\.2byte/\.short/g'
 
 export CPP := $(PREFIX)cpp


### PR DESCRIPTION
Setting up the PC port was very easy. The difficulty came from the fact its documentation was incredibly scattered. I have done the following to help improve ease of use:

- Merged Lunos's Pastebin instructions into INSTALL.md
- Altered INSTALL.md to use the modern compiler by default (also changed INSTALL.md to reflect this)
- Added an argument to the make command allowing you to run Makefile_pc with command: `make pc`
- Added SDL to .gitignore