### PR TITLE
Fix frontier pass crash when trying to view the map

### DIFF
--- a/src/frontier_pass.c
+++ b/src/frontier_pass.c
@@ -686,7 +686,13 @@ static u32 FreeFrontierPassGfx(void)
 
 static void VBlankCB_FrontierPass(void)
 {
+    #ifdef UBFIX
+    //Game doesn't clear VBlank interrupt handler when freeing sPassGfx
+    //Check was added instead of disabling VBlank after freeing to ensure there are no new bugs introduced
+    if (sPassGfx != NULL && sPassGfx->zooming)
+    #else
     if (sPassGfx->zooming)
+    #endif
     {
         SetBgAffine(2,
                     sBgAffineCoords[sPassData->areaToShow - 1][0] << 8,


### PR DESCRIPTION
The crash happens because frontier pass tries to execute VBlank interrupt with code that expects sPassGfx not to be cleared. Fixed with a NULL check. This crash does not happen on GBA due to lack of MMU.