### PR TITLE
Fix backdrop color not getting updated between lines

### DIFF
--- a/src/platform/sdl2.c
+++ b/src/platform/sdl2.c
@@ -1885,9 +1885,10 @@ static void DrawFrame(uint16_t *pixels)
             backdropColor = alphaBrightnessDecrease(backdropColor);
             break;
         }
-    }
 
-    memsetu16(scanlines, backdropColor, DISPLAY_WIDTH * DISPLAY_HEIGHT);
+        // Make sure to push the backdrop color back to PLTT mem.
+        *(uint16_t *)PLTT = backdropColor;
+    }
 
     for (i = 0; i < DISPLAY_HEIGHT; i++)
     {
@@ -1899,6 +1900,9 @@ static void DrawFrame(uint16_t *pixels)
                     gIntrTable[0]();
         }
 
+        // Render the backdrop color before the each individual scanline.
+        // HBlank interrupt code can have changed it inbetween lines.
+        memsetu16(scanlines[i], *(uint16_t *)PLTT, DISPLAY_WIDTH);
         DrawScanline(scanlines[i], i);
         
         REG_DISPSTAT |= INTR_FLAG_HBLANK;


### PR DESCRIPTION
I'm not sure whether blending should happen for each scanline as well, but for the backdrop color itself I'm certain that this is more correct.