### PR TITLE
Fix frameskip in win32 version

### DIFF
--- a/src/platform/win32.c
+++ b/src/platform/win32.c
@@ -659,11 +659,10 @@ u16 Platform_GetKeyInput(void)
 
 void VDraw()
 {
-    DrawFrame(lpBitmapBits);
-    
-    
     if (frameskipCounter == 0)
     {
+        DrawFrame(lpBitmapBits);
+
         //convert pixels to to the correct format
         for (int x = 0; x < DISPLAY_HEIGHT * DISPLAY_WIDTH ; x++)
         {

--- a/src/platform/win32.c
+++ b/src/platform/win32.c
@@ -664,10 +664,12 @@ void VDraw()
         DrawFrame(lpBitmapBits);
 
         //convert pixels to to the correct format
-        for (int x = 0; x < DISPLAY_HEIGHT * DISPLAY_WIDTH ; x++)
+        uint32_t* bitmap32 = (uint32_t*)lpBitmapBits; //cast to 32bit so we could convert two pixels at once
+        while (bitmap32 != &lpBitmapBits[DISPLAY_HEIGHT * DISPLAY_WIDTH])
         {
-            uint16_t color = lpBitmapBits[x];
-            lpBitmapBits[x] = ((color & 0x001F) << 10) | (color & 0x03E0) | ((color & 0x7C00) >> 10);
+            uint32_t color32 = *bitmap32;
+            *bitmap32 = ((color32 & 0x1F001F) << 10) | (color32 & 0x83E083E0) | ((color32 & 0x7C007C00) >> 10);
+            bitmap32++;
         }
         
         if (bitBltEnabled)


### PR DESCRIPTION
The pixel data was still being drawn even on frameskip frames